### PR TITLE
Chain import exceptions for tools.restricted.EnableXmlCli and tools.EnableXmlCli

### DIFF
--- a/src/xmlcli/XmlCliLib.py
+++ b/src/xmlcli/XmlCliLib.py
@@ -792,12 +792,13 @@ def ConfXmlCli(SkipEnable=0):
       try:
         from .tools.restricted import EnableXmlCli as exc
       except (ModuleNotFoundError, ImportError) as e:
-        from .tools import EnableXmlCli as exc
-      except ImportError:
-        log.error(f'Import error on EnableXmlCli, current Python version {sys.version}')
-        CloseInterface()
-        LastErrorSig = 0x13E4  # import error
-        return 0xF
+        try:
+          from .tools import EnableXmlCli as exc
+        except ImportError:
+          log.error(f'Import error on EnableXmlCli, current Python version {sys.version}')
+          CloseInterface()
+          LastErrorSig = 0x13E4  # import error
+          return 0xF
       Status = exc.EnableXmlCli()
       if Status == 0:
         Status = 2
@@ -824,11 +825,12 @@ def TriggerXmlCliEntry():
   try:
     from .tools.restricted import EnableXmlCli as exc
   except (ModuleNotFoundError, ImportError) as e:
-    from .tools import EnableXmlCli as exc
-  except ImportError:
-    log.error(f'Import error on EnableXmlCli, current Python version {sys.version}')
-    LastErrorSig = 0x13E4  # import error
-    return 1
+    try:
+      from .tools import EnableXmlCli as exc
+    except ImportError:
+      log.error(f'Import error on EnableXmlCli, current Python version {sys.version}')
+      LastErrorSig = 0x13E4  # import error
+      return 1
   status = exc.XmlCliApiAuthenticate()
   if status:
     LastErrorSig = 0xE7CA  # Error Triggering XmlCli command, Authentication Failed


### PR DESCRIPTION
While trying to fo:

`from .tools import EnableXmlCli as exc`

If the import statement fails the log message is not being displayed since the exception has already being caught, e.g.:
![image](https://github.com/user-attachments/assets/c515dbbe-79eb-4a60-8901-9f1be1fa9ec3)

The expected behavior should be like this:
![image](https://github.com/user-attachments/assets/bcc5a564-584d-40d7-8150-196b3b966cbf)

From a real-world test using python3.12
![image](https://github.com/user-attachments/assets/1009f5fd-b833-4691-8ac1-f60575386787)

Behavior with this patch:
![image](https://github.com/user-attachments/assets/53405add-dc1d-4b69-bc59-8d0c77371605)


